### PR TITLE
BugFix: ConcurrentModificationException in MouseTracker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.earnix.webk</groupId>
     <artifactId>web-k-parent</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.7</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.earnix.webk</groupId>
     <artifactId>web-k-parent</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/web-k-application/pom.xml
+++ b/web-k-application/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.earnix.webk</groupId>
         <artifactId>web-k-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>web-k-application</artifactId>

--- a/web-k-application/pom.xml
+++ b/web-k-application/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.earnix.webk</groupId>
         <artifactId>web-k-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>web-k-application</artifactId>

--- a/web-k-core/pom.xml
+++ b/web-k-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.earnix.webk</groupId>
         <artifactId>web-k-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>web-k-core</artifactId>

--- a/web-k-core/pom.xml
+++ b/web-k-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.earnix.webk</groupId>
         <artifactId>web-k-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>web-k-core</artifactId>

--- a/web-k-core/src/main/java/com/earnix/webk/runtime/ui_events/impl/MouseEventsAdapter.java
+++ b/web-k-core/src/main/java/com/earnix/webk/runtime/ui_events/impl/MouseEventsAdapter.java
@@ -16,9 +16,8 @@ import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
-import java.awt.Point;
+import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
@@ -51,7 +50,7 @@ public class MouseEventsAdapter implements MouseListener, MouseMotionListener, M
 
     @Getter
     MouseEvent lastAwtMouseEvent;
-    JFrame currentFrame;
+    Window currentWindow;
 
     FrameEventsListener frameEventsListener;
 
@@ -71,15 +70,16 @@ public class MouseEventsAdapter implements MouseListener, MouseMotionListener, M
         frameEventsListener = new FrameEventsListener(this);
 
         panel.addHierarchyListener(e -> {
-            JFrame frame = (JFrame) SwingUtilities.getRoot(panel);
-            if (frame != currentFrame) {
-                if (currentFrame != null) {
-                    currentFrame.removeWindowListener(frameEventsListener);
+
+            Window window = (Window) SwingUtilities.getRoot(panel);
+            if (window != currentWindow) {
+                if (currentWindow != null) {
+                    currentWindow.removeWindowListener(frameEventsListener);
                 }
-                if (frame != null) {
-                    frame.addWindowListener(frameEventsListener);
+                if (window != null) {
+                    window.addWindowListener(frameEventsListener);
                 }
-                currentFrame = frame;
+                currentWindow = window;
             }
         });
 

--- a/web-k-core/src/main/java/com/earnix/webk/swing/MouseTracker.java
+++ b/web-k-core/src/main/java/com/earnix/webk/swing/MouseTracker.java
@@ -58,6 +58,12 @@ public class MouseTracker implements MouseListener, MouseMotionListener, MouseWh
      */
     public MouseTracker(BasicPanel panel) {
         this.panel = panel;
+
+        /**
+         * {@link CopyOnWriteArrayList} is used to allow iterate and modify handlers at the same time. It may happen
+         * if the handler tries to add/remove itself directly or indirectly during the iteration over the handlers
+         * (e.g. on {@link #fireMouseUp(Box) event.}.
+         */
         handlers = new CopyOnWriteArrayList<>();
     }
 

--- a/web-k-core/src/main/java/com/earnix/webk/swing/MouseTracker.java
+++ b/web-k-core/src/main/java/com/earnix/webk/swing/MouseTracker.java
@@ -31,6 +31,7 @@ import java.awt.event.MouseWheelListener;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 
 /**
@@ -46,7 +47,7 @@ import java.util.List;
 public class MouseTracker implements MouseListener, MouseMotionListener, MouseWheelListener {
     
     BasicPanel panel;
-    HashSet<FSMouseListener> handlers;
+    List<FSMouseListener> handlers;
     Box lastHoveredBox;
     boolean enabled;
 
@@ -57,7 +58,7 @@ public class MouseTracker implements MouseListener, MouseMotionListener, MouseWh
      */
     public MouseTracker(BasicPanel panel) {
         this.panel = panel;
-        handlers = new HashSet<>();
+        handlers = new CopyOnWriteArrayList<>();
     }
 
     /**

--- a/web-k-examples/pom.xml
+++ b/web-k-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.earnix.webk</groupId>
         <artifactId>web-k-parent</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>web-k-examples</artifactId>

--- a/web-k-examples/pom.xml
+++ b/web-k-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.earnix.webk</groupId>
         <artifactId>web-k-parent</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>web-k-examples</artifactId>


### PR DESCRIPTION
On mouse event MouseTracker.java iterates  over and call to registered listeners. The user's mouse listener implementation may add/remove listeners which cause ConcurrentModificationException.